### PR TITLE
refactor: 타입 선언 방식 통일화 및 계층별 타입 컨벤션 정의

### DIFF
--- a/IMPLEMENTATION.md
+++ b/IMPLEMENTATION.md
@@ -80,3 +80,61 @@ components는 "재사용이 가능한" 이라는 점에 집중하고있는 반�
 문서에 API명세 route가 다음과 같이 되어있습니다. `/api/customer/{id}/purchases`.
 하지만 Backend code를 보았을 때 `/api/customers/{id}/purchases` 로 요청해야하여
 프론트 코드에서 위와같이 호출하고 있습니다.
+
+---
+
+### 추가된 내용
+
+Typescript 타입 선언 컨벤션
+
+#### 기본 원칙
+
+- 모든 타입 선어는 기본적으로 `type`을 사용합니다.
+
+Type 선언 방식에 `interface`와 `type`이 있지만 하나의 type 선언방식으로 정의하여 다음과 같은 효과를 기대합니다.
+
+1. 일관성 있는 코드베이스 유지
+2. 개발자의 의사결정 비용 감소
+3. 명확한 컨벤션 제시
+
+#### 계층별 타입 사용 방식
+
+1. **API 계층**
+
+   - Zod 스키마를 사용하여 런타임 데이터 검증
+   - 스키마로부터 타입 추론 (`z.infer<typeof Schema>`)
+
+```typescript
+// 1. API 계층
+export const UserSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+```
+
+2. **Data 계층 (React Query 등)**
+
+   - 유틸리티 타입을 활용하여 API 응답 타입과 정확한 동기화
+   - 예: `type Response = Awaited<ReturnType<typeof apiFunction>>`
+
+```typescript
+// 2. Data 계층
+type UserResponse = Awaited<ReturnType<typeof getUser>>;
+```
+
+3. **UI 계층 (feature, props)**
+   - API 응답 전체 구조가 아닌 필요한 데이터 타입만 사용
+   - 예: `type CardProps = { item: Purchase }`
+
+```typescript
+// 3. UI 계층
+type UserCardProps = {
+  user: User;
+  onEdit?: (id: number) => void;
+};
+```
+
+#### interface 사용 케이스
+
+- 복잡한 상속 구조가 필요한 경우
+- 개발자가 명확한 이유로 interface가 필요하다고 생각이 되는 경우

--- a/apps/frontend/src/api/customer/getCustomers/index.ts
+++ b/apps/frontend/src/api/customer/getCustomers/index.ts
@@ -2,7 +2,7 @@ import { safeGet } from '~/lib'
 import { z } from 'zod'
 import { CustomerSchema } from './type'
 
-export interface GetCustomersParams {
+export type GetCustomersParams = {
   sortBy?: 'asc' | 'desc'
   name?: string
 }

--- a/apps/frontend/src/components/bottom-sheet/index.tsx
+++ b/apps/frontend/src/components/bottom-sheet/index.tsx
@@ -5,7 +5,7 @@ import { useScrollLock } from '~/hooks'
 import Portal from '../portal'
 import { SerializedStyles } from '@emotion/react'
 
-interface BottomSheetProps {
+type BottomSheetProps = {
   isOpen: boolean
   onClose: () => void
   children: React.ReactNode

--- a/apps/frontend/src/components/error-boundary/index.tsx
+++ b/apps/frontend/src/components/error-boundary/index.tsx
@@ -34,7 +34,7 @@ type Props<ErrorType extends Error = Error> = {
   ignoreError?: IgnoreErrorType
 }
 
-interface State<ErrorType extends Error = Error> {
+type State<ErrorType extends Error = Error> = {
   error: ErrorType | null
 }
 

--- a/apps/frontend/src/components/input/index.tsx
+++ b/apps/frontend/src/components/input/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { InputHTMLAttributes, forwardRef } from 'react'
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+type InputProps = InputHTMLAttributes<HTMLInputElement> & {
   label?: string
   error?: string
 }

--- a/apps/frontend/src/components/portal/index.tsx
+++ b/apps/frontend/src/components/portal/index.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from 'react'
+import { PropsWithChildren, useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 
-interface PortalProps {
-  children: React.ReactNode
-}
+type PortalProps = PropsWithChildren
 
 const Portal: React.FC<PortalProps> = ({ children }) => {
   const [portalNode, setPortalNode] = useState<HTMLElement | null>(null)

--- a/apps/frontend/src/components/skeleton/index.tsx
+++ b/apps/frontend/src/components/skeleton/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { motion } from 'motion/react'
 
-interface SkeletonProps {
+type SkeletonProps = {
   width?: string | number
   height?: string | number
   borderRadius?: string | number

--- a/apps/frontend/src/features/customer/customerList/index.tsx
+++ b/apps/frontend/src/features/customer/customerList/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import { useCustomersSearch, useCustomersSearchResult } from '~/hooks/query/useCustomers'
 import { AArrowUp, AArrowDown } from '@mynaui/icons-react'
 import Input from '~/components/input'
@@ -34,7 +34,9 @@ function CustomerList() {
       return undefined
     })
   }
-  const renderCustomerRows = useCallback((customers: typeof data) => {
+
+  // useCallback, useMemo 제거
+  const renderCustomerRows = (customers: typeof data) => {
     return customers.map((customer) => (
       <S.TableRow key={customer.id} onClick={() => handleRowClick(customer.id)} style={{ cursor: 'pointer' }}>
         <S.TableCell>{customer.id}</S.TableCell>
@@ -43,9 +45,9 @@ function CustomerList() {
         <S.TableCell>{customer.count}</S.TableCell>
       </S.TableRow>
     ))
-  }, [])
+  }
 
-  const renderContent = useMemo(() => {
+  const renderContent = () => {
     const hasError = searchError !== null || searchCustomersError !== null
 
     return match({ data, hasError, isSearching })
@@ -62,7 +64,7 @@ function CustomerList() {
       .with({ data: [] }, () => <CustomerListEmpty />)
       .with({ data: P.array(P.any) }, ({ data: customers }) => renderCustomerRows(customers))
       .exhaustive()
-  }, [data, searchError, searchCustomersError, isSearching, handleSearch, renderCustomerRows])
+  }
 
   useEffect(() => {
     if (!sortBy) return
@@ -101,7 +103,7 @@ function CustomerList() {
               <S.TableHeader>구매 횟수</S.TableHeader>
             </S.TableRow>
           </S.TableHead>
-          <S.TableBody>{renderContent}</S.TableBody>
+          <S.TableBody>{renderContent()}</S.TableBody>
         </S.Table>
       </S.TableWrapper>
 

--- a/apps/frontend/src/features/customer/purchasesByCustomer/PurchasesList/index.tsx
+++ b/apps/frontend/src/features/customer/purchasesByCustomer/PurchasesList/index.tsx
@@ -2,7 +2,7 @@ import { usePurchasesByCustomer } from '~/hooks/query/usePurchasesByCustomer'
 import { match, P } from 'ts-pattern'
 import * as S from './style'
 
-interface PurchasesListProps {
+type PurchasesListProps = {
   customerId: number
 }
 

--- a/apps/frontend/src/features/customer/purchasesByCustomer/index.tsx
+++ b/apps/frontend/src/features/customer/purchasesByCustomer/index.tsx
@@ -7,7 +7,7 @@ import { ErrorBoundary } from '~/components/error-boundary'
 import PurchasesByCustomerError from './error'
 import { QueryErrorResetBoundary } from '@tanstack/react-query'
 
-interface PurchasesByCustomerProps {
+type PurchasesByCustomerProps = {
   customerId: number | null
   onClose: () => void
   isOpen: boolean

--- a/apps/frontend/src/lib/axios/type.ts
+++ b/apps/frontend/src/lib/axios/type.ts
@@ -2,14 +2,14 @@ export type ApiSuccessResponse<T> = T
 
 export type ApiResponse<T = unknown> = ApiSuccessResponse<T> | ApiFailureResponse
 
-export interface ApiFailureResponse {
+export type ApiFailureResponse = {
   message: 'FAILURE'
   code: null
   data: null
   errors: ErrorSchema
 }
 
-export interface ErrorSchema {
+export type ErrorSchema = {
   code: number
   message: string
 }


### PR DESCRIPTION
## 변경 사항
- 기본 타입 선언 방식을 `type`으로 통일
- API, Data, UI 계층별 타입 사용 기준 수립
- 타입 선언 관련 컨벤션 문서화 (IMPLEMENTATION.md)

## 주요 변경 내용
1. 타입 선언 방식 통일화
   - 기본적으로 모든 타입 선언은 `type` 키워드 사용
   - 특수한 경우에만 `interface` 사용 (복잡한 상속 구조 등)

2. 계층별 타입 사용 기준 수립
   - API 계층: Zod 스키마 기반 타입 정의
   - Data 계층: 유틸리티 타입을 활용한 API 응답 타입 동기화
   - UI 계층: 필요한 데이터 타입만 명시적 사용

3. 컨벤션 문서화
   - IMPLEMENTATION.md에 타입 선언 관련 가이드라인 추가
   - 예시 코드와 권장/비권장 패턴 명시

## 변경 이유
- 타입 선언 방식의 일관성 확보
- 개발자 의사결정 비용 감소
- 명확한 컨벤션 제시를 통한 유지보수성 향상

## 고민해보면 좋을 점
두 선언 방식중에 여러 차이점이 있지만 고려해봐야할 부분은 성능 문제입니다.
typescript에 대한 여러 글과 영상을 남기는 [Matt Pocock](https://www.youtube.com/watch?v=zM9UPcIyyhQ)는 해당 영상에서 수천건의 type과 interface를 비교해봤지만 이렇다할 성능 이슈는 발현되지 않았다고 얘기합니다. 
- 위 부분은 실제로 측정 테스트를 해보면 좋을 것 같습니다.

추가로 이전 Typescript 문서에서는 `interface is faster than types`라는 내용이 있었지만 현재는 삭제되어 찾아볼 수 없는 상황입니다.
물론 interface는 type보다 타입 확장에 용이합니다. 하지만 interface는 객체만을 구현할 수 있기에 사용성면에서는 더 떨어진다고 볼 수 있습니다.

두 가지 방식을 때에 따라서 모두 채택하면 더할나위없이 좋겠지만 개발자는 매 순간 챌린지를 해야하고, 이는 코드에 일관성을 떨어트리는 결과를 초래할 수 있기에 다음과 같은 방식을 제안합니다.